### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,19 +29,24 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "php": "^8.0",
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.4",
+    "dreamfactory/df-system": "~0.6.2",
     "dreamfactory/df-file": "~0.8",
     "dreamfactory/php-webhdfs": "~1.1.1",
-    "dreamfactory/df-database": "~1.0",
+    "dreamfactory/df-database": "~1.4",
     "dreamfactory/df-sqldb": "~1.0",
     "ext-json": "*",
     "ext-pdo": "*",
     "ext-odbc": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Database/ODBCConnection.php
+++ b/src/Database/ODBCConnection.php
@@ -7,16 +7,16 @@ use Illuminate\Database\Query\Grammars\MySqlGrammar;
 
 class ODBCConnection extends Connection
 {
-    function getDefaultQueryGrammar()
+    protected function getDefaultQueryGrammar()
     {
-        return new MySqlGrammar();
+        return new MySqlGrammar($this);
     }
 
-    function getDefaultSchemaGrammar()
+    protected function getDefaultSchemaGrammar()
     {
         $schemaGrammar = $this->getConfig('options.grammar.schema');
         if ($schemaGrammar) {
-            return new $schemaGrammar;
+            return new $schemaGrammar($this);
         }
         return parent::getDefaultSchemaGrammar();
     }


### PR DESCRIPTION
## Summary

Wave 2 of the L11 -> L13 upgrade campaign for `df-hadoop`. Brings the Hadoop connector (HDFS/WebHDFS file service + Hive over ODBC SQL service) onto Laravel 13.7.

## Changes

**`composer.json`**
- `php: ^8.0` -> `^8.3`
- Add `laravel/helpers: ^1.8` (polyfills `array_get`, `camel_case`, `array_except` call sites inherited from df-core).
- `dreamfactory/df-system: ~0.4` -> `~0.6.2` (aligns with df-core's L13 constraint).
- `dreamfactory/df-database: ~1.0` -> `~1.4` (aligns with df-sqldb's L13 constraint).
- Replace dev stack with the L13 matrix: `laravel/framework ^13.7`, `phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery/mockery ^1.6`, `nunomaduro/collision ^8.6`.

**`src/Database/ODBCConnection.php`** (only source change)
- L13's `Illuminate\Database\Grammar::__construct(Connection $connection)` is mandatory and `withTablePrefix()` is gone. Update `getDefaultQueryGrammar()` and `getDefaultSchemaGrammar()` to instantiate `MySqlGrammar` and the optional `options.grammar.schema` override with `$this`.
- Mark both methods `protected` to match parent visibility.

No other source changes were required: `ODBCBuilder`, `ODBCConnector`, `ODBCProcessor`, `ODBCPdo`, `ODBCPdoStatement`, the `WebHDFS` / `HDFileSystem` file stack, `HiveSchema` (extends `df-sqldb`'s `MySqlSchema`), `HiveService` (extends `df-sqldb`'s `SqlDb`), and the `Models`/`Resources`/`ServiceProvider` are L13-clean.

## Validation

**Stage 1** (isolated composer install, `/tmp/df-hadoop-stage1` with sibling path repos for df-core/df-system/df-database/df-sqldb/df-file)
- `composer validate --no-check-publish` clean.
- `composer install --no-dev` resolves under Laravel 13.7.0.
- All 15 namespaced classes pass `class_exists()`.
- `laravel/helpers` polyfills (`array_get`, `camel_case`, `array_except`) registered.
- Reflective `ODBCConnection` construction succeeds; `getDefaultQueryGrammar()` returns a valid `Illuminate\Database\Query\Grammars\MySqlGrammar` bound to the connection; `getDefaultSchemaGrammar()` returns null in default config (parent behavior).

**Stage 2** (`shift-173254` host-app worktree at `/tmp/df-l13-test-hadoop`, sibling path repos + standard L13 strip-list of `df-mongo-logs` / `df-git` / `df-oauth` / `df-mcp-server` and `MongoDB\Laravel\MongoDBServiceProvider` commented)
- `composer install --no-dev` resolves; df-hadoop installed via path repo.
- `php artisan package:discover --ansi` registers `dreamfactory/df-hadoop` with no errors.
- Full smoke check passes inside the host worktree (15 classes + 3 helper polyfills + reflective Connection ctor).

## Test plan

- [x] Stage 1 composer install --no-dev (L13.7.0)
- [x] Stage 1 class_exists smoke for all 15 src classes
- [x] Stage 1 reflective ODBCConnection ctor + grammar smoke
- [x] Stage 2 composer install --no-dev in shift-173254 host app
- [x] Stage 2 package:discover registers df-hadoop
- [x] Stage 2 full smoke
- [ ] Live ODBC connection test against a Hive/Impala server (deferred; no test fixture)
- [ ] Live WebHDFS test against a Hadoop NameNode (deferred; no test fixture)

## Hadoop-driver context

- Hive SQL access is over ODBC via the system's `odbc_*` PHP extension. The default driver path defaults to `libmaprhiveodbc64.so` (MapR Hive ODBC), overridable via the `HIVE_SERVER_ODBC_DRIVER_PATH` env var or per-service `options.driver_path`.
- HDFS file access is over `dreamfactory/php-webhdfs ~1.1.1` (WebHDFS REST), unchanged.
- The Query Grammar deliberately falls back to MySQL syntax (Hive accepts MySQL-flavored DDL/DML for the SHOW/DESCRIBE/SELECT shapes the connector emits).

## Risk / scope

Trivially small surface (one `protected`+`$this` change). The `options.grammar.schema` config override path was previously documented but not exercised in core; the new behavior continues to allow a custom Grammar class but now correctly wires it to the connection per L13's contract.